### PR TITLE
Use "prefer" prefix for formality

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const input = options.input || getSrtFileInFolder();
 let output = options.output;
 const source = options.source;
 const target = options.target || 'FR';
-const formality = options.formal ? 'more' : 'less';
+const formality = options.formal ? 'prefer_more' : 'prefer_less';
 const logDebug = options.debug;
 const displayUsageLimit = options.usagelimit;
 


### PR DESCRIPTION
Makes it prefer either less or more but not complain if the language doesn't support the formality option.

Nice project. Also I noticed that it's using the api.deepl.com endpoint by default, it has to be api-free.deepl.com if you are using the free API. I don't know if this is something that has changed since you wrote this or if you just prefer it that way, but I thought I'd let you know just in case since it's more likely for people to use the free API.